### PR TITLE
Update average_treatment_effect.R

### DIFF
--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -66,11 +66,7 @@ average_treatment_effect = function(forest,
     Y.hat <- forest$Y.hat
     W.orig <- forest$W.orig
     W.hat <- forest$W.hat
-    clusters <- forest$clusters[subset]
-  }
-  
-  if(is.null(predictions)) {
-    predictions <- predict(forest)$predictions
+    clusters <- forest$clusters
   }
   
   if (!("causal_forest" %in% class(forest))) {
@@ -129,7 +125,14 @@ average_treatment_effect = function(forest,
   
   # Retreive pointwise treatment effect predictions from forest, and
   # compute naive average effect estimates (notice that this uses OOB)
-  tau.hat.pointwise <- predictions[subset]
+  if(is.null(predictions)) {
+    predictions <- predict(forest)$predictions
+  }
+  
+  if(!is.null(subset)) {
+    predictions <- predictions[subset]
+  }
+  tau.hat.pointwise <- predictions
   if (target.sample == "all") {
     tau.avg.raw <- mean(tau.hat.pointwise)
   } else if (target.sample == "treated") {


### PR DESCRIPTION
Moving the "prediction" to part to where necessary. Subsetting "predictions" only if subset is provided (otherwise results in empty vector). Also removing redundant subsetting of clusters when subset is null.

Thanks for working on the Group (Subset) Average Treatment Effect (GATE) :-)
Hoping to see it in the main package. LMK if you want me to pull the updated file myself.